### PR TITLE
feat: 支持引用图片文件上传

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,32 @@
 from datetime import datetime
 import os
 
+try:
+    import emoji
+    from emoji import unicode_codes
+
+    if not hasattr(unicode_codes, 'get_emoji_unicode_dict'):
+        def get_emoji_unicode_dict(lang):
+            return {data[lang]: char for char, data in emoji.EMOJI_DATA.items() if lang in data}
+        unicode_codes.get_emoji_unicode_dict = get_emoji_unicode_dict
+    
+    if not hasattr(unicode_codes, 'EMOJI_UNICODE'):
+        unicode_codes.EMOJI_UNICODE = {'en': get_emoji_unicode_dict('en')}
+
+    if not hasattr(emoji, 'get_emoji_regexp'):
+        import re
+        _emoji_regexp = None
+        def get_emoji_regexp():
+            global _emoji_regexp
+            if _emoji_regexp is None:
+                emojis = sorted(emoji.EMOJI_DATA.keys(), key=len, reverse=True)
+                pattern = '|'.join(re.escape(e) for e in emojis)
+                _emoji_regexp = re.compile(pattern)
+            return _emoji_regexp
+        emoji.get_emoji_regexp = get_emoji_regexp
+except ImportError:
+    pass
+
 from astrbot import logger
 from astrbot.api.event import filter
 from astrbot.api.star import Context, Star, StarTools, register
@@ -17,7 +43,7 @@ from .src.utils import get_first_image, get_message_history, check_group_level_p
     "astrbot_plugin_qun_album",
     "Zhalslar&Foolllll",
     "群相册插件，记录群友怪话",
-    "1.1.2",
+    "1.1.3",
 )
 class AdminPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_qun_album # 这是你的插件的唯一识别名。
 display_name: 群相册插件
 desc: "[仅napcat] 群相册插件，记录群友怪话" # 插件简短描述
 help: 略  # 插件的帮助信息
-version: v1.1.2 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.1.3 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar&Foolllll # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_qun_album

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pilmoji>=2.0.0
-emoji>=2.0.0
+pilmoji==2.0.4
+emoji==1.7.0
 pillow

--- a/src/draw.py
+++ b/src/draw.py
@@ -73,7 +73,8 @@ def wrap_text(text: str, font: ImageFont.FreeTypeFont, max_width: int) -> list[s
 def pad_emojis(text: str) -> str:
     try:
         import emoji
-        return emoji.replace_emoji(text, replace=lambda chars, data: f" {chars} ")
+        pattern = emoji.get_emoji_regexp()
+        return re.sub(pattern, lambda m: f" {m.group(0)} ", text)
     except Exception:
         return text
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

新增对从文件消息片段中处理图片上传的支持，并相应更新插件的元数据和依赖。

新功能：
- 当文件类型的消息片段包含受支持的图片格式时，允许从中提取图片。
- 在生成的回复文本和消息历史中，将文件片段表示为带标签的文件占位符。

改进：
- 调整 emoji 填充实现方式，使用 emoji 正则表达式，以兼容已固定版本的依赖库。
- 将插件版本元数据更新为 v1.1.3，以反映新能力。

构建：
- 固定 pilmoji 和 emoji 依赖版本，以确保在不同环境中保持一致的 emoji 处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for handling image uploads from file message segments and update plugin metadata and dependencies accordingly.

New Features:
- Allow image extraction from file-type message segments when they contain supported image formats.
- Represent file segments as labeled file placeholders in generated reply text and message history.

Enhancements:
- Adjust emoji padding implementation to use the emoji regular expression for compatibility with pinned library versions.
- Bump plugin version metadata to v1.1.3 to reflect the new capabilities.

Build:
- Pin pilmoji and emoji dependency versions to ensure consistent emoji handling behavior across environments.

</details>