### PR TITLE
pref: 优化兼容性

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,34 +36,36 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
 from .src.draw import generate_meme, generate_stitched_meme
-from .src.utils import get_first_image, get_message_history, check_group_level_permission
-
-
-@register(
-    "astrbot_plugin_qun_album",
-    "Zhalslar&Foolllll",
-    "群相册插件，记录群友怪话",
-    "1.1.3",
+from .src.utils import (
+    check_group_level_permission,
+    get_first_image,
+    get_message_history,
+    normalize_album_list_response,
+    upload_album_image_with_fallback,
 )
+
+
 class AdminPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
         self.conf = config
         self.plugin_data_dir = StarTools.get_data_dir("astrbot_plugin_qun_album")
 
-    async def _get_album_id_by_name(
+    async def _get_album_by_name(
         self, event: AiocqhttpMessageEvent, name: str | None = None
-    ) -> str | None:
-        album_list = await event.bot.get_qun_album_list(
+    ) -> dict | None:
+        raw_album_list = await event.bot.get_qun_album_list(
             group_id=int(event.get_group_id())
         )
+        album_list = normalize_album_list_response(raw_album_list)
         if not album_list:
             return None
         if not name:
-            return album_list[0]["album_id"]
+            return album_list[0]
         for album in album_list:
             if album["name"] == name:
-                return album["album_id"]
+                return album
+        return None
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE)
     @filter.command("上传群相册", alias={"up"})
@@ -83,12 +85,14 @@ class AdminPlugin(Star):
         elif len(parts) == 2:
             real_album_name = parts[1]
             
-        album_id = await self._get_album_id_by_name(event, real_album_name)
-        if not album_id:
+        album = await self._get_album_by_name(event, real_album_name)
+        if not album:
             yield event.plain_result("该相册不存在")
             return
 
         # 检查群等级
+        album_id = album.get("album_id")
+        resolved_album_name = album.get("name") or real_album_name or ""
         level_threshold = self.conf.get("level_threshold", 0)
         show_title = self.conf.get("show_title", True)
         
@@ -124,11 +128,12 @@ class AdminPlugin(Star):
         with save_path.open("wb") as f:
             f.write(image)
 
-        await event.bot.upload_image_to_qun_album(
-            group_id=group_id,
-            album_id=album_id,
-            album_name=real_album_name,
-            file=str(save_path),
+        await upload_album_image_with_fallback(
+            event=event,
+            raw_group_id=group_id,
+            raw_album_id=album_id,
+            album_name=resolved_album_name,
+            save_path=save_path,
         )
         event.stop_event()
         logger.info("上传群相册成功")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_qun_album # 这是你的插件的唯一识别名。
 display_name: 群相册插件
 desc: "[仅napcat] 群相册插件，记录群友怪话" # 插件简短描述
 help: 略  # 插件的帮助信息
-version: v1.1.3 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.1.4 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar&Foolllll # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_qun_album

--- a/src/draw.py
+++ b/src/draw.py
@@ -149,7 +149,7 @@ def make_dialog_box(text: str, name_w: int) -> Image.Image:
     
     current_y = text_start_y
     if Pilmoji:
-        logger.info("pilmoji")
+        logger.debug("pilmoji")
         emoji_offset_y = max(1, int(descent * 0.9))
         with Pilmoji(box, emoji_position_offset=(0, emoji_offset_y)) as pilmoji:
             for line in lines:

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,13 +2,80 @@
 import base64
 from pathlib import Path
 import random
-from typing import Optional
+from typing import Any, Optional
 from aiocqhttp import CQHttp
 import aiohttp
 from astrbot.api import logger
 from astrbot.core.message.components import Image, Plain, Reply, At, File
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import AiocqhttpMessageEvent
+
+
+def normalize_album_list_response(payload: Any) -> list[dict]:
+    """兼容旧版 list 返回和新版 data.album_list/list 包装格式。"""
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return []
+
+    data = payload.get("data")
+    if isinstance(data, dict):
+        album_list = data.get("album_list") or data.get("list")
+        if isinstance(album_list, list):
+            return [item for item in album_list if isinstance(item, dict)]
+
+    album_list = payload.get("album_list") or payload.get("list")
+    if isinstance(album_list, list):
+        return [item for item in album_list if isinstance(item, dict)]
+    return []
+
+
+async def upload_album_image_with_fallback(
+    event: AiocqhttpMessageEvent,
+    raw_group_id: int,
+    raw_album_id: Any,
+    album_name: str,
+    save_path: Path,
+) -> None:
+    """
+    兼容旧版和新版 NapCat 的群相册上传参数。
+    """
+    file_path = str(save_path.absolute())
+    file_uri = f"file://{save_path.absolute()}"
+    file_base64 = f"base64://{base64.b64encode(save_path.read_bytes()).decode('ascii')}"
+    candidates = [
+        ("group=int|album_id=str|album_name=str|file=raw_path", raw_group_id, str(raw_album_id), str(album_name), file_path),
+        ("group=int|album_id=str|album_name=str|file=base64", raw_group_id, str(raw_album_id), str(album_name), file_base64),
+        ("group=int|album_id=str|album_name=str|file=file_uri", raw_group_id, str(raw_album_id), str(album_name), file_uri),
+    ]
+
+    last_error = None
+    failure_modes: list[tuple[str, str]] = []
+    for mode, group_value, album_id_value, album_name_value, file_value in candidates:
+        logger.debug(
+            "[qun_album] 尝试上传群相册图片: "
+            f"模式={mode}, group_id={group_value}({type(group_value).__name__}), "
+            f"album_id={album_id_value}({type(album_id_value).__name__}), "
+            f"album_name={album_name_value}({type(album_name_value).__name__}), "
+            f"file_type={type(file_value).__name__}, file_preview={file_value[:120]}"
+        )
+        try:
+            await event.bot.upload_image_to_qun_album(
+                group_id=group_value,
+                album_id=album_id_value,
+                album_name=album_name_value,
+                file=file_value,
+            )
+            logger.debug(f"[qun_album] 上传群相册成功，使用模式: {mode}")
+            return
+        except Exception as e:
+            last_error = e
+            failure_modes.append((mode, str(e)))
+            logger.warning(f"[qun_album] 上传群相册失败，模式={mode}: {e}")
+
+    if failure_modes:
+        logger.debug(f"[qun_album] 各上传模式失败详情: {failure_modes}")
+    raise last_error
 
 
 async def download_image(url: str, http: bool = True) -> bytes | None:


### PR DESCRIPTION
适配新版本nc

## Summary by Sourcery

调整群相册插件以同时支持旧版和新版 NapCat 相册 API，并更新插件版本。

新功能：
- 增加对多种 NapCat 群相册列表返回格式的兼容处理。
- 引入基于回退机制的上传器，在上传相册图片时尝试多种参数/文件编码方式。

改进：
- 优化相册查询逻辑，从仅返回相册 ID 改为返回完整相册元数据，以便更灵活地使用。
- 将 Pilmoji 日志级别从 info 降为 debug，以减少日志噪音。

杂项：
- 将插件元数据版本更新到 v1.1.4。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the group album plugin to support both old and new NapCat album APIs and update the plugin version.

New Features:
- Add compatibility handling for multiple NapCat group album list response formats.
- Introduce a fallback-based uploader that tries several parameter/file encodings when uploading album images.

Enhancements:
- Refine album lookup to return full album metadata instead of only the album ID for more flexible usage.
- Downgrade Pilmoji logging from info to debug to reduce log noise.

Chores:
- Bump plugin metadata version to v1.1.4.

</details>